### PR TITLE
Mark fallback nodes with respective attribute

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -362,6 +362,7 @@ class Extension_Multilingual extends Extension
                                 $element[$language] = clone $element[self::$languages[0]];
 
                                 $element[$language]->setAttribute('lang', $language);
+                                $element[$language]->setAttribute('fallback', true);
                             }
                         }
                     }


### PR DESCRIPTION
Hi,

Sometimes it is better to react to unavailable translations, not just show the fallback. This attribute helps to distinguish such translations.
