### PR TITLE
Quick fix for association field. 

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -253,7 +253,7 @@ class Extension_Multilingual extends Extension
 
     // datasource output entries
 
-    private function findEntries(XMLElement $xml)
+    private function findEntries(XMLElement $xml, $entries_name = 'entry')
     {
         // check if xml has child elements
 
@@ -269,7 +269,7 @@ class Extension_Multilingual extends Extension
 
                     // check if element is entry
 
-                    if ($element->getName() === 'entry') {
+                    if ($element->getName() === $entries_name) {
 
                         // process fields
 
@@ -316,27 +316,32 @@ class Extension_Multilingual extends Extension
 
                     if (in_array($match[1], self::$languages)) {
 
-                        // remove language segment from element handle
+							  // remove language segment from element handle
 
-                        $element_handle = preg_replace('/-' . $match[1] . '$/', '', $element_handle);
-                        $element_mode   = $element->getAttribute('mode');
+							  $element_handle = preg_replace('/-' . $match[1] . '$/', '', $element_handle);
+							  $element_mode = $element->getAttribute('mode');
 
-                        // set new name and language
+							  // set new name and language
 
-                        $element->setName($element_handle);
-                        $element->setAttribute('lang', $match[1]);
-                        $element->setAttribute('translated', 'yes');
+							  $element->setName($element_handle);
+							  $element->setAttribute('lang', $match[1]);
+							  $element->setAttribute('translated', 'yes');
 
-                        // store element
+							  // store element
 
-                        $multilingual_elements[$element_handle . ($element_mode ? ':' . $element_mode : '')][$match[1]] = $element;
+							  $multilingual_elements[$element_handle . ($element_mode ? ':' . $element_mode : '')][$match[1]] = $element;
 
-                        // remove element
+							  // remove element
 
-                        $xml->removeChildAt($element_index);
-                    }
-                }
-            }
+							  $xml->removeChildAt($element_index);
+		          }
+					 } else {
+						 $test = $element->getChildrenByName('item');
+						 if (!empty($element->getChildrenByName('item'))) {
+							 $this->findEntries($element, 'item');
+						 }
+					 }
+				}
 
             // check for stored multilingual elements
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -305,42 +305,43 @@ class Extension_Multilingual extends Extension
             foreach ($elements as $element_index => $element) {
 
                 // get element handle
+                if (is_object($element)) {
+                    $element_handle = $element->getName();
 
-                $element_handle = $element->getName();
+                    // check if element handle is multilingual
 
-                // check if element handle is multilingual
+                    if (preg_match('/-([a-z]{2})$/', $element_handle, $match)) {
 
-                if (preg_match('/-([a-z]{2})$/', $element_handle, $match)) {
+                        // check if language is supported
 
-                    // check if language is supported
+                        if (in_array($match[1], self::$languages)) {
 
-                    if (in_array($match[1], self::$languages)) {
+                           // remove language segment from element handle
 
-							  // remove language segment from element handle
+                           $element_handle = preg_replace('/-' . $match[1] . '$/', '', $element_handle);
+                           $element_mode = $element->getAttribute('mode');
 
-							  $element_handle = preg_replace('/-' . $match[1] . '$/', '', $element_handle);
-							  $element_mode = $element->getAttribute('mode');
+                           // set new name and language
 
-							  // set new name and language
+                           $element->setName($element_handle);
+                           $element->setAttribute('lang', $match[1]);
+                           $element->setAttribute('translated', 'yes');
 
-							  $element->setName($element_handle);
-							  $element->setAttribute('lang', $match[1]);
-							  $element->setAttribute('translated', 'yes');
+                           // store element
 
-							  // store element
+                           $multilingual_elements[$element_handle . ($element_mode ? ':' . $element_mode : '')][$match[1]] = $element;
 
-							  $multilingual_elements[$element_handle . ($element_mode ? ':' . $element_mode : '')][$match[1]] = $element;
+                           // remove element
 
-							  // remove element
-
-							  $xml->removeChildAt($element_index);
-		          }
-					 } else {
-						 $test = $element->getChildrenByName('item');
-						 if (!empty($element->getChildrenByName('item'))) {
-							 $this->findEntries($element, 'item');
-						 }
-					 }
+                           $xml->removeChildAt($element_index);
+                    }
+                    } else {
+                       $test = $element->getChildrenByName('item');
+                       if (!empty($element->getChildrenByName('item'))) {
+                          $this->findEntries($element, 'item');
+                       }
+                    }
+                }
 				}
 
             // check for stored multilingual elements

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -253,7 +253,7 @@ class Extension_Multilingual extends Extension
 
     // datasource output entries
 
-    private function findEntries(XMLElement $xml, $entries_name = 'entry')
+    private function findEntries(XMLElement $xml, $node_name = 'entry')
     {
         // check if xml has child elements
 
@@ -269,7 +269,7 @@ class Extension_Multilingual extends Extension
 
                     // check if element is entry
 
-                    if ($element->getName() === $entries_name) {
+                    if ($element->getName() === $node_name) {
 
                         // process fields
 
@@ -305,7 +305,7 @@ class Extension_Multilingual extends Extension
             foreach ($elements as $element_index => $element) {
 
                 // get element handle
-                if (is_object($element)) {
+                if ($element instanceof XMLElement) {
                     $element_handle = $element->getName();
 
                     // check if element handle is multilingual
@@ -334,15 +334,14 @@ class Extension_Multilingual extends Extension
                            // remove element
 
                            $xml->removeChildAt($element_index);
-                    }
+                        }
                     } else {
-                       $test = $element->getChildrenByName('item');
-                       if (!empty($element->getChildrenByName('item'))) {
-                          $this->findEntries($element, 'item');
-                       }
+                        if (!empty($element->getChildrenByName('item'))) {
+                           $this->findEntries($element, 'item');
+                        }
                     }
                 }
-				}
+            }
 
             // check for stored multilingual elements
 


### PR DESCRIPTION
A quick fix for language-processing for fields pulled in via association field. Tested only in one site and one section (that is, basically untested). 

Look at non-language fields to see if they contain item element and put them through processEntries function.
Add a parameter to processFields function.

Apparently my editor screwed up the spacing in a bunch of lines I didn't touch. The changes are in 256 & 272 and then starting from 336.
